### PR TITLE
Refactor manifest discovery to look for `esy.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "is-ci": "^1.0.10",
     "is-webpack-bundle": "^1.0.0",
     "js-yaml": "^3.10.0",
+    "json5": "^0.5.1",
     "leven": "^2.0.0",
     "loud-rejection": "^1.2.0",
     "micromatch": "^2.3.11",

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -258,11 +258,16 @@ export class Install {
     };
 
     for (const registry of Object.keys(registries)) {
-      const {filename} = registries[registry];
-      const loc = path.join(cwd, filename);
-      if (!await fs.exists(loc)) {
-        continue;
+      const {filenameList} = registries[registry];
+      let locToFind;
+      for (const filename of filenameList) {
+        locToFind = path.join(cwd, filename);
+        if (!await fs.exists(locToFind)) {
+          continue;
+        }
       }
+      invariant(locToFind != null, 'Cannot find manifest');
+      const loc = locToFind;
 
       this.rootManifestRegistries.push(registry);
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -412,9 +412,11 @@ export function main({
 
     // add manifests
     for (const registryName of registryNames) {
-      const possibleLoc = path.join(config.cwd, registries[registryName].filename);
-      const manifest = fs.existsSync(possibleLoc) ? fs.readFileSync(possibleLoc, 'utf8') : 'No manifest';
-      log.push(`${registryName} manifest: ${indent(manifest)}`);
+      for (const filename of registries[registryName].filenameList) {
+        const possibleLoc = path.join(config.cwd, filename);
+        const manifest = fs.existsSync(possibleLoc) ? fs.readFileSync(possibleLoc, 'utf8') : 'No manifest';
+        log.push(`${registryName} manifest (${filename}): ${indent(manifest)}`);
+      }
     }
 
     // lockfile

--- a/src/registries/base-registry.js
+++ b/src/registries/base-registry.js
@@ -37,7 +37,7 @@ export default class BaseRegistry {
   }
 
   // the filename to use for package metadata
-  static filename: string;
+  static filenameList: Array<string>;
 
   //
   reporter: Reporter;

--- a/src/registries/esy-registry.js
+++ b/src/registries/esy-registry.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-import NpmRegistry from './npm-registry.js';
-
-export default class EsyRegistry extends NpmRegistry {
-  static filename = 'esy.json';
-}

--- a/src/registries/index.js
+++ b/src/registries/index.js
@@ -2,10 +2,8 @@
 
 import YarnRegistry from './yarn-registry.js';
 import NpmRegistry from './npm-registry.js';
-import EsyRegistry from './esy-registry.js';
 
 export const registries = {
-  esy: EsyRegistry,
   npm: NpmRegistry,
   yarn: YarnRegistry,
 };
@@ -14,7 +12,6 @@ export const registryNames = Object.keys(registries);
 
 export type RegistryNames = $Keys<typeof registries>;
 export type ConfigRegistries = {
-  esy: EsyRegistry,
   npm: NpmRegistry,
   yarn: YarnRegistry,
 };

--- a/src/registries/npm-registry.js
+++ b/src/registries/npm-registry.js
@@ -77,7 +77,7 @@ export default class NpmRegistry extends Registry {
     this.folder = 'node_modules';
   }
 
-  static filename = 'package.json';
+  static filenameList = ['esy.json', 'package.json'];
 
   static escapeName(name: string): string {
     // scoped packages contain slashes and the npm registry expects them to be escaped

--- a/src/registries/yarn-registry.js
+++ b/src/registries/yarn-registry.js
@@ -44,7 +44,7 @@ export default class YarnRegistry extends NpmRegistry {
     this.homeConfig = {};
   }
 
-  static filename = 'yarn.json';
+  static filenameList = ['yarn.json'];
 
   homeConfigLoc: string;
   homeConfig: Object;

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -6,7 +6,6 @@ import RegistryNpm from './registries/npm-resolver.js';
 import RegistryYarn from './registries/yarn-resolver.js';
 
 export const registries = {
-  esy: RegistryNpm,
   npm: RegistryNpm,
   yarn: RegistryYarn,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@esy-ocaml/esy-opam@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-opam/-/esy-opam-0.0.5.tgz#9eb602dbf2c65c38ea9183ecadfc9a08247695d7"
+"@esy-ocaml/esy-opam@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-opam/-/esy-opam-0.0.7.tgz#368dd776b0e13d0db4e5ffe5ced12a7fde44eb96"
 
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.1"


### PR DESCRIPTION
* [x] discover `esy.json`
* [x] add support for json5 in `esy.json`
* [ ] consider allowing json5 for `package.json` too (need to convert to proper JSON on publish
* [ ] discover `opam`
