### PR TITLE
Windows support

### DIFF
--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -25,7 +25,7 @@ const externals =  {
     commonjs: '@esy-ocaml/esy-opam',
     commonjs2: '@esy-ocaml/esy-opam',
   },
-  'esy-cygwin': 'esy-cygwin'
+  'esy-bash': 'esy-bash'
 };
 
 //

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -24,7 +24,8 @@ const externals =  {
   '@esy-ocaml/esy-opam': {
     commonjs: '@esy-ocaml/esy-opam',
     commonjs2: '@esy-ocaml/esy-opam',
-  }
+  },
+  'esy-cygwin': 'esy-cygwin'
 };
 
 //

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -240,7 +240,7 @@ async function applyPatches(dest, patches) {
     await fs.writeFile(patchFilename, patch.content, {encoding: 'utf8'});
     try {
       if (isWindows) {
-          await bashExec(`patch -p1 < ${patchFilename}`, {
+          await bashExec(`patch -p1 -i ${toCygwinPath(patchFilename)}`, {
             cwd: dest,
             stdio: 'inherit',
           });

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -240,8 +240,7 @@ async function applyPatches(dest, patches) {
     await fs.writeFile(patchFilename, patch.content, {encoding: 'utf8'});
     try {
       if (isWindows) {
-          console.log("patch::dest - " + dest)
-          await bashExec(`patch -p2 -i ${patchFilename}`, {
+          await bashExec(`patch -p0 -i ${patchFilename}`, {
             cwd: dest,
             stdio: 'inherit',
           });

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -240,7 +240,7 @@ async function applyPatches(dest, patches) {
     await fs.writeFile(patchFilename, patch.content, {encoding: 'utf8'});
     try {
       if (isWindows) {
-          await bashExec(`patch -p1 < ${toCygwinPath(patchFilename)}`, {
+          await bashExec(`patch -p1 < ${patchFilename}`, {
             cwd: dest,
             stdio: 'inherit',
           });

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -240,7 +240,8 @@ async function applyPatches(dest, patches) {
     await fs.writeFile(patchFilename, patch.content, {encoding: 'utf8'});
     try {
       if (isWindows) {
-          await bashExec(`patch -p1 -i ${toCygwinPath(patchFilename)}`, {
+          console.log("patch::dest - " + dest)
+          await bashExec(`patch -p2 -i ${patchFilename}`, {
             cwd: dest,
             stdio: 'inherit',
           });

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -240,7 +240,7 @@ async function applyPatches(dest, patches) {
     await fs.writeFile(patchFilename, patch.content, {encoding: 'utf8'});
     try {
       if (isWindows) {
-          await bashExec(`patch -p0 -i ${patchFilename}`, {
+          await bashExec(`patch -p1 -i ${patchFilename}`, {
             cwd: dest,
             stdio: 'inherit',
           });

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -23,10 +23,6 @@ import * as fs from '../util/fs.js';
 import * as child from '../util/child.js';
 import DecompressZip from 'decompress-zip';
 
-// We don't want to bundle `esy-bash` with the built webpack bundle,
-// so we use `__non_webpack_require__`
-const { bashExec, toCygwinPath } = __non_webpack_require__("esy-bash");
-
 const isWindows = os.platform() === "win32";
 
 export default class OpamFetcher extends TarballFetcher {
@@ -173,6 +169,7 @@ async function unpackOpamTarball(
     if (isWindows) {
         // On Windows, we use the 'esy-bash' cygwin environment, since `tar` doesn't come out of the box.
         // Note that `tar` is one command that requires the paths to be in the Cygwin-format vs the Windows format.
+        const { bashExec, toCygwinPath } = __non_webpack_require__("esy-bash");
         await bashExec(`tar ${unpackOptions} ${toCygwinPath(filename)} -C ${toCygwinPath(dest)}`);
     } else {
         await child.exec(`tar ${unpackOptions} ${filename} -C ${dest}`);
@@ -240,6 +237,7 @@ async function applyPatches(dest, patches) {
     await fs.writeFile(patchFilename, patch.content, {encoding: 'utf8'});
     try {
       if (isWindows) {
+          const { bashExec, toCygwinPath } = __non_webpack_require__("esy-bash");
           await bashExec(`patch -p1 -i ${patchFilename}`, {
             cwd: dest,
             stdio: 'inherit',

--- a/src/fetchers/opam-fetcher.js
+++ b/src/fetchers/opam-fetcher.js
@@ -153,7 +153,7 @@ function writeJson(filename, object): Promise<void> {
   return fs.writeFile(filename, data, {encoding: 'utf8'});
 }
 
-const {bashExec} = __non_webpack_require__("esy-cygwin")
+const {bashExec} = __non_webpack_require__("esy-bash")
 const normalizePathForBash = (p) => {
     const normalizedPath = path.normalize(p)
     

--- a/src/resolvers/exotics/opam-resolver/config.js
+++ b/src/resolvers/exotics/opam-resolver/config.js
@@ -4,7 +4,7 @@ export const OPAM_SCOPE = 'opam';
 
 export const OPAM_REPOSITORY = process.env.ESY_OPAM_REPOSITORY
   ? process.env.ESY_OPAM_REPOSITORY
-  : 'https://github.com/ocaml/opam-repository.git';
+  : 'https://github.com/fdopen/opam-repository-mingw.git';
 
 export const OPAM_REPOSITORY_OVERRIDE = process.env.ESY_OPAM_REPOSITORY_OVERRIDE
   ? process.env.ESY_OPAM_REPOSITORY_OVERRIDE

--- a/src/resolvers/exotics/opam-resolver/config.js
+++ b/src/resolvers/exotics/opam-resolver/config.js
@@ -1,6 +1,14 @@
 /* @flow */
 
+const os = require("os");
+
 export const OPAM_SCOPE = 'opam';
+
+const isWindows = os.platform() === "win32";
+
+const defaultRepository = isWindows ?
+  'https://github.com/fdopen/opam-repository-mingw.git'
+  : 'https://github.com/ocaml/opam-repository.git';
 
 export const OPAM_REPOSITORY = process.env.ESY_OPAM_REPOSITORY
   ? process.env.ESY_OPAM_REPOSITORY

--- a/src/resolvers/exotics/opam-resolver/config.js
+++ b/src/resolvers/exotics/opam-resolver/config.js
@@ -1,14 +1,6 @@
 /* @flow */
 
-const os = require("os");
-
 export const OPAM_SCOPE = 'opam';
-
-const isWindows = os.platform() === "win32";
-
-const defaultRepository = isWindows ?
-  'https://github.com/fdopen/opam-repository-mingw.git'
-  : 'https://github.com/ocaml/opam-repository.git';
 
 export const OPAM_REPOSITORY = process.env.ESY_OPAM_REPOSITORY
   ? process.env.ESY_OPAM_REPOSITORY

--- a/src/resolvers/exotics/opam-resolver/opam-repository.js
+++ b/src/resolvers/exotics/opam-resolver/opam-repository.js
@@ -56,6 +56,7 @@ async function initImpl(config: Config) {
   const onUpdate = () => {
     config.reporter.info('Updating OPAM repository...');
   };
+  console.log(`- Cloning OPAM repository from ${OPAM_REPOSITORY} to ${checkoutPath}`);
   const [_, override, urlIndex] = await Promise.all([
     cloneOrUpdateRepository(OPAM_REPOSITORY, checkoutPath, {
       onClone,

--- a/src/resolvers/exotics/opam-resolver/opam-repository.js
+++ b/src/resolvers/exotics/opam-resolver/opam-repository.js
@@ -56,7 +56,6 @@ async function initImpl(config: Config) {
   const onUpdate = () => {
     config.reporter.info('Updating OPAM repository...');
   };
-  console.log(`- Cloning OPAM repository from ${OPAM_REPOSITORY} to ${checkoutPath}`);
   const [_, override, urlIndex] = await Promise.all([
     cloneOrUpdateRepository(OPAM_REPOSITORY, checkoutPath, {
       onClone,


### PR DESCRIPTION
This PR adds windows support for the following:
- Use the forked mingw repository for OPAM, which has some windows-specific fixes.
- For the `tar` command, send to `esy-bash` to execute in the cygwin environment.
- For the `patch` command, send to `esy-bash` to execute in the cygwin environment.

Note that this PR makes the assumption that we would _not_ be using this repository standalone, and only as a part of the core `esy` repo. We don't include the `esy-bash` package for this reason - it would be double-installed, since we install it at the root and at the `_release` folder of the `esy` repo.

In addition, the assumption is that this strategy is going to be temporary, and long-term we are going to switch to `esyi` - so there is some duplication of logic here. I believe this to be acceptable since it's not meant to be maintained long-term, but rather to bootstrap `esy` such that we can switch fully to `esyi` - but @jordwalke @andreypopp - let me know if you have any feedback! 👍 