### PR TITLE
Windows: Default to forked repo on Windows; add logging to show repo being used.

### DIFF
--- a/src/resolvers/exotics/opam-resolver/config.js
+++ b/src/resolvers/exotics/opam-resolver/config.js
@@ -4,7 +4,7 @@ export const OPAM_SCOPE = 'opam';
 
 export const OPAM_REPOSITORY = process.env.ESY_OPAM_REPOSITORY
   ? process.env.ESY_OPAM_REPOSITORY
-  : 'https://github.com/ocaml/opam-repository.git';
+  : process.platform === 'win32' ? 'https://github.com/fdopen/opam-repository-mingw.git' : 'https://github.com/ocaml/opam-repository.git';
 
 export const OPAM_REPOSITORY_OVERRIDE = process.env.ESY_OPAM_REPOSITORY_OVERRIDE
   ? process.env.ESY_OPAM_REPOSITORY_OVERRIDE

--- a/src/resolvers/exotics/opam-resolver/opam-repository.js
+++ b/src/resolvers/exotics/opam-resolver/opam-repository.js
@@ -51,10 +51,10 @@ export async function getManifestCollection(
 async function initImpl(config: Config) {
   const checkoutPath = path.join(config.cacheFolder, 'opam-repository');
   const onClone = () => {
-    config.reporter.info('Fetching OPAM repository...');
+    config.reporter.info(`Fetching OPAM repository: ${OPAM_REPOSITORY}...`);
   };
   const onUpdate = () => {
-    config.reporter.info('Updating OPAM repository...');
+    config.reporter.info(`Updating OPAM repository: ${OPAM_REPOSITORY}...`);
   };
   const [_, override, urlIndex] = await Promise.all([
     cloneOrUpdateRepository(OPAM_REPOSITORY, checkoutPath, {


### PR DESCRIPTION
This change updates the default `OPAM_REPOSITORY` configuration to point to the forked OPAM repository on Windows, and the normal OPAM repository on non-windows platforms.

In addition, it adds some explicit logging to make it clear which repo is being picked up: 
```
[1/4] Resolving packages...
[2/4] Fetching packages...
info Fetching OPAM repository: https://github.com/fdopen/opam-repository-mingw.git...
```

Tested on Windows and OS X to verify that they picked up the correct repositories (https://github.com/fdopen/opam-repository-mingw & https://github.com/ocaml/opam-repository, respectively)
